### PR TITLE
Refactor, changing memory handling

### DIFF
--- a/src/file_handler.c
+++ b/src/file_handler.c
@@ -7,7 +7,8 @@
 char* make_full_path(char *path, char *file) {
   char *full_path = malloc(strlen(path) + strlen(file) + 2);
   full_path[0] = '\0';
-  strcat(full_path, path);
+  /* char full_path[strlen(path) + strlen(file) + 1]; */
+  strcpy(full_path, path);
   strcat(full_path, file);
   return full_path;
 }

--- a/src/main.c
+++ b/src/main.c
@@ -54,7 +54,7 @@ void handle_client (int *client, char *root_folder) {
   struct packet_request* r = parse_request(request);
 
   if ((strcmp(r->request_resource, "/")) == 0) {
-    r->request_resource = "/index.html";
+    strcpy(r->request_resource, "/index.html");
   }
 
   char* requested_path = make_full_path(root_folder, r->request_resource);
@@ -65,6 +65,7 @@ void handle_client (int *client, char *root_folder) {
   //write(*client, packet->message_body, atol(packet->header->content_length));
   send(*client, message, strlen(message), MSG_NOSIGNAL);
   send(*client, packet->message_body, atol(packet->header->content_length), MSG_NOSIGNAL);
+  free(requested_path);
   free(message);
   memset(request, 0 ,BUFFER_SIZE);
   destroy_http_packet(packet);

--- a/src/packet_builder.c
+++ b/src/packet_builder.c
@@ -27,7 +27,10 @@ struct http_packet* make_http_packet(char* file_path) {
   struct http_packet* packet = malloc(sizeof(struct http_packet));
   if (check_existence(file_path) < 0) {
     packet->header = make_404_error();
-    packet->message_body = "<html>Resource not found!</html>";
+    packet->message_body = malloc(sizeof(char)*64);
+    /* packet->message_body[0] = '\0'; */
+    /* packet->message_body = "<html>Resource not found!</html>"; */
+    strcpy(packet->message_body, "<html>Resource not found!</html>");
     return packet;
   } else {
     FILE* f = get_file(file_path);
@@ -70,7 +73,7 @@ struct http_header* make_200_ok (long int length, char* content_type) {
 
 void destroy_http_packet(struct http_packet* h) {
   /* free(h->header->content_length); */
-  /* free(h->header->content_type); */
+  free(h->header->content_type);
   free(h->header);
   free(h->message_body);
   free(h);

--- a/src/packet_builder.c
+++ b/src/packet_builder.c
@@ -16,9 +16,6 @@ char* get_packet_string(struct http_packet* packet) {
   strcat(message, "CONNECTION: ");
   strcat(message, packet->header->connection_status);
   strcat(message, "\r\n\r\n");
-  /* strcat(message, packet->message_body); */
-  //printf("%d\n", (int) strlen((const char*) packet->message_body));
-  //memcpy(message, packet->message_body, atol(packet->header->content_length));
   return message;
 
 }
@@ -28,8 +25,6 @@ struct http_packet* make_http_packet(char* file_path) {
   if (check_existence(file_path) < 0) {
     packet->header = make_404_error();
     packet->message_body = malloc(sizeof(char)*64);
-    /* packet->message_body[0] = '\0'; */
-    /* packet->message_body = "<html>Resource not found!</html>"; */
     strcpy(packet->message_body, "<html>Resource not found!</html>");
     return packet;
   } else {
@@ -46,34 +41,29 @@ struct http_packet* make_http_packet(char* file_path) {
 
 struct http_header* make_404_error() {
   struct http_header* header = (struct http_header*) malloc(sizeof(struct http_header));
-  header->response_code = "HTTP/1.1 404 NOT FOUND";
-  header->server_name = "Todd's HTTP";
-  header->content_length = "32";
-  header->content_type = "text html";
-  header->connection_status = "KEEP-ALIVE";
+  strcpy(header->response_code, "HTTP/1.1 404 NOT FOUND");
+  strcpy(header->server_name, "Todd's HTTP");
+  strcpy(header->content_length, "32");
+  strcpy(header->content_type, "text/html");
+  strcpy(header->connection_status, "KEEP-ALIVE");
   return header;
 }
 
 struct http_header* make_200_ok (long int length, char* content_type) {
+  struct http_header* header = malloc(sizeof(struct http_header));
   char length_string[10];
   sprintf(length_string, "%li", length);
-  struct http_header* header = malloc(sizeof(struct http_header));
-  header->response_code = "HTTP/1.1 200 OK";
-  header->server_name = "Todd's HTTP";
+  /* struct http_header* header = malloc(sizeof(struct http_header)); */
+  strcpy(header->response_code, "HTTP/1.1 200 OK");
+  strcpy(header->server_name, "Todd's HTTP");
   /* header->content_type = "text html"; */
-  header->content_type = malloc(strlen(content_type)+1);
-  header->content_type[0] = '\0';
-  strcat(header->content_type, content_type);
-  header->content_length = malloc(strlen(length_string)+1);
-  header->content_length[0] = '\0';
-  strcat(header->content_length, length_string);
-  header->connection_status = "CLOSE";
+  strcpy(header->content_type, content_type);
+  strcpy(header->content_length, length_string);
+  strcpy(header->connection_status, "CLOSE");
   return header;
 }
 
 void destroy_http_packet(struct http_packet* h) {
-  /* free(h->header->content_length); */
-  free(h->header->content_type);
   free(h->header);
   free(h->message_body);
   free(h);

--- a/src/packet_builder.c
+++ b/src/packet_builder.c
@@ -34,6 +34,7 @@ struct http_packet* make_http_packet(char* file_path) {
     packet->header = make_200_ok(length, content_type);
     //packet->message_body = get_file_contents(f, length);
     packet->message_body = get_file_contents(f, length);
+    fclose(f);
     return packet;
   }
   return NULL; // temporary for WIP

--- a/src/packet_builder.h
+++ b/src/packet_builder.h
@@ -7,11 +7,11 @@
 #include "file_handler.h"
 
 struct http_header {
-  char* response_code;
-  char* server_name;
-  char* content_length; // length of body
-  char* content_type;
-  char* connection_status;
+  char response_code[32];
+  char server_name[32];
+  char content_length[8]; // length of body
+  char content_type[16];
+  char connection_status[16];
 };
 
 struct http_packet {

--- a/src/packet_parser.c
+++ b/src/packet_parser.c
@@ -3,8 +3,9 @@
 
 struct packet_request* parse_request(char* message) {
   struct packet_request* request = malloc(sizeof(struct packet_request));
-  request->request_method = malloc(sizeof(char)*5);
-  request->request_resource = malloc(sizeof(char)*100);
+  request->request_method = malloc(sizeof(char)*8);
+  request->request_resource = malloc(sizeof(char)*128);
+  request->request_resource[0] = '\0';
   request->host = malloc(sizeof(char)*32);
 
   char* delim = "\r\n, ";
@@ -17,7 +18,7 @@ struct packet_request* parse_request(char* message) {
     if ((strcmp("GET", line_token)) == 0) {
       strcpy(request->request_method, "GET");
       line_token = strtok(NULL, delim);
-      strcpy(request->request_resource, line_token);
+      stpcpy(request->request_resource, line_token);
     }
     if ((strcmp("Host:", line_token)) == 0) {
       line_token = strtok(NULL, delim);
@@ -33,8 +34,9 @@ void destroy_packet(struct packet_request* packet) {
   /* packet->request_method = NULL; */
   /* packet->request_resource = NULL; */
   /* packet->host = NULL; */
-  free(packet->request_method);
   /* free(packet->request_resource); */
+  free(packet->request_method);
   free(packet->host);
   free(packet);
+  packet = NULL;
 }

--- a/src/packet_parser.c
+++ b/src/packet_parser.c
@@ -3,10 +3,6 @@
 
 struct packet_request* parse_request(char* message) {
   struct packet_request* request = malloc(sizeof(struct packet_request));
-  request->request_method = malloc(sizeof(char)*8);
-  request->request_resource = malloc(sizeof(char)*128);
-  request->request_resource[0] = '\0';
-  request->host = malloc(sizeof(char)*32);
 
   char* delim = "\r\n, ";
   char* line_token;
@@ -35,8 +31,6 @@ void destroy_packet(struct packet_request* packet) {
   /* packet->request_resource = NULL; */
   /* packet->host = NULL; */
   /* free(packet->request_resource); */
-  free(packet->request_method);
-  free(packet->host);
   free(packet);
   packet = NULL;
 }

--- a/src/packet_parser.h
+++ b/src/packet_parser.h
@@ -7,9 +7,9 @@
 #include <stdlib.h>
 
 struct packet_request {
-  char* request_method;
-  char* request_resource;
-  char* host;
+  char request_method[8];
+  char request_resource[256];
+  char host[32];
 };
 
 // parses a packet


### PR DESCRIPTION
Originally, all memory was being pushed off to the heap. This has been changed for allocating structures on the heap and having defined sizes for elements of structures.